### PR TITLE
Minor fixes for the build on macOS

### DIFF
--- a/libavdevice/sixel.c
+++ b/libavdevice/sixel.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <sys/signal.h>
 #include <termios.h>
+#include <time.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sixel.h>


### PR DESCRIPTION
At least some macOS versions need `time.h` for `nanosleep` to be available (tested on macOS 10.15).

P. S. Edited: another error was an outcome of applying a patch incorrectly, should be ignored. Only the missing header one is relevant.